### PR TITLE
Use OrderedDict for language list

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import collections
 import flask
 import mwapi
 import mwoauth
@@ -96,7 +97,7 @@ def authentication_area():
 
 
 def get_all_languages():
-    langs = {}
+    langs = collections.OrderedDict()
     sparql = SPARQLWrapper("https://query.wikidata.org/sparql")
     sparql.setQuery("""SELECT ?number_of_lexemes ?language ?languageLabel ?languageCode
     WITH {SELECT ?language (COUNT(?l) AS ?number_of_lexemes) WHERE {


### PR DESCRIPTION
On Toolforge, an older Python version which does not guarantee dictionary insertion order is used, so to preserve the order of the SPARQL query results (i. e., by number of lexemes without senses), explicitly use an `OrderedDict`.

Fixes #4.

---

Unfortunately, I don’t have a system with an older Python version where I could test this… @Vesihiisi can you perhaps try it out on Toolforge before merging?