### PR TITLE
Use correct property in query

### DIFF
--- a/app.py
+++ b/app.py
@@ -189,7 +189,7 @@ def get_with_missing_senses(lang):
         SELECT ?l ?lemma ?posLabel WHERE {
            ?l a ontolex:LexicalEntry ; dct:language ?language ;
                 wikibase:lemma ?lemma .
-          ?language wdt:P218 '%s'.
+          ?language wdt:P424 '%s'.
               OPTIONAL {
           ?l wikibase:lexicalCategory ?pos .
                 SERVICE wikibase:label


### PR DESCRIPTION
We have to use the same property for the language code in all queries, otherwise the inconsistency can result in errors. In this particular case, the problem is that not all Wikimedia language codes (selected by
the “index” query) are also ISO 639-1 codes (selected by the “add” query), since some of them are more than two letters. (In fact, a few Wikimedia language codes aren’t ISO 639 codes of any kind.)

Fixes #6.