### PR TITLE
Implement route for lexemes by a user

### DIFF
--- a/app.py
+++ b/app.py
@@ -280,6 +280,8 @@ def add(lang):
         response = submit_sense_from_request()
         if response:
             return response
+        else:
+            return flask.redirect(flask.url_for('add', lang=lang))
 
     words = get_with_missing_senses(lang)
     random_word = random.choice(words)
@@ -296,6 +298,8 @@ def user(user_name):
         response = submit_sense_from_request()
         if response:
             return response
+        else:
+            return flask.redirect(flask.url_for('user', user_name=user_name))
 
     words = get_with_missing_senses_by_user(user_name)
     random_word = random.choice(words)

--- a/app.py
+++ b/app.py
@@ -158,13 +158,20 @@ def build_senses(form_data, lang):
     return sense_data
 
 
-def current_url():
-    return flask.url_for(
-        flask.request.endpoint,
-        _external=True,
-        _scheme=flask.request.headers.get('X-Forwarded-Proto', 'http'),
-        **flask.request.view_args
-    )
+@app.template_global()
+def current_url(external=True):
+    if external:
+        return flask.url_for(
+            flask.request.endpoint,
+            _external=True,
+            _scheme=flask.request.headers.get('X-Forwarded-Proto', 'http'),
+            **flask.request.view_args
+        )
+    else:
+        return flask.url_for(
+            flask.request.endpoint,
+            **flask.request.view_args
+        )
 
 
 def generate_auth():

--- a/app.py
+++ b/app.py
@@ -222,6 +222,7 @@ def add(lang):
 
         if 'oauth' in app.config:
             form_data = flask.request.form
+            lang = form_data['lang']
             senses = build_senses(form_data, lang)
             word_id = form_data["word_id"]
             return submit_lexeme(word_id, senses, lang)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,13 @@
 {% extends "base.html" %}
 {% block main %}
 <h1>Wikidata Senses</h1>
+{% if logged_in_user_name() %}
+<p>
+  <a href="{{ url_for('user', user_name=logged_in_user_name().replace(' ', '_')) }}">
+    Lexemes created by you which don’t have any senses yet
+  </a>
+</p>
+{% endif %}
 <p>
   Here are the languages that have most Sense-less Lemmas:
 </p>

--- a/templates/lemma.html
+++ b/templates/lemma.html
@@ -10,6 +10,7 @@
 </div>
 <form method="post" id="sense_adder">
 <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+<input name="lang" type="hidden" value="{{ lang }}">
 <div class="form-group">
 <label for="sense">Add the first Sense to this Lemma!</label>
 

--- a/templates/lemma.html
+++ b/templates/lemma.html
@@ -14,7 +14,7 @@
 <div class="form-group">
 <label for="sense">Add the first Sense to this Lemma!</label>
 
-<input {{ form_attributes('sense') }} class="form-control" autofocus="autofocus" autocomplete="off" required>
+<input {{ form_attributes('sense') }} class="form-control" autofocus="autofocus" autocomplete="off" required lang="{{ lang }}">
 <p><input {{ form_attributes('word_id') }} type = "hidden" value = "{{ word_id }}" /></p>
 </div>
 <a href="{{ url_for('add', lang=lang) }}" class="btn btn-secondary">Give me another lemma</a>

--- a/templates/lemma.html
+++ b/templates/lemma.html
@@ -17,7 +17,7 @@
 <input {{ form_attributes('sense') }} class="form-control" autofocus="autofocus" autocomplete="off" required lang="{{ lang }}">
 <p><input {{ form_attributes('word_id') }} type = "hidden" value = "{{ word_id }}" /></p>
 </div>
-<a href="{{ url_for('add', lang=lang) }}" class="btn btn-secondary">Give me another lemma</a>
+<a href="{{ current_url(external=False) }}" class="btn btn-secondary">Give me another lemma</a>
 <button type="submit" class="btn btn-primary float-right">Add</button>
 </form>
 


### PR DESCRIPTION
Implements #11. See individual commit messages for details.

This isn’t ready for merging yet – as mentioned in the last commit message, I still need to put a link to “your lexemes” somewhere. I’m not yet sure where it should be: it could be in the OAuth area after your username (but we don’t have much space for explanation there), or on the index page below the language list. @Vesihiisi what do you think?