### PR TITLE
Disallow embedding the tool in other pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -385,3 +385,15 @@ def oauth_callback():
     flask.session['oauth_access_token'] = dict(
         zip(access_token._fields, access_token))
     return flask.redirect(flask.url_for('index'))
+
+@app.after_request
+def denyFrame(response):
+    """Disallow embedding the tool’s pages in other websites.
+
+    If other websites can embed this tool’s pages, e. g. in <iframe>s,
+    other tools hosted on tools.wmflabs.org can send arbitrary web
+    requests from this tool’s context, bypassing the referrer-based
+    CSRF protection.
+    """
+    response.headers['X-Frame-Options'] = 'deny'
+    return response


### PR DESCRIPTION
If we allow other pages to embed our tool, they can “remote-control” it if they’re running on tools.wmflabs.org, bypassing CSRF protection.

---

Another security fix. You know the drill, I already deployed it (and tested that the tool still works). Sorry for the inconvenience, but until the foundation deigns to implement [T125589](https://phabricator.wikimedia.org/T125589 "Allow each tool to have its own subdomain for browser sandbox/cookie isolation") we have to waste our time with patchwork fixes like this. (It should be the last one for now, but I also thought that on the last few changes.)