### PR TITLE
Don't make links black

### DIFF
--- a/static/styles/styles.css
+++ b/static/styles/styles.css
@@ -16,7 +16,6 @@
 }
 
 .lemma_info a {
-    color: black;
     text-decoration: none;
 }
 
@@ -34,18 +33,15 @@
     display: inline-block;
     background-color: #fdcb6e;
     text-decoration: none;
-    color: black;
 }
 
 .lemma_info_top li a {
     display: block;
     padding: 5px 20px;
-    color: black;
 }
 
 .lang_list li a:hover {
     text-decoration: none;
-    color: black;
 }
 
 .lang_list li {
@@ -62,10 +58,8 @@
 .lang_list li a {
     display: block;
     padding: 5px 10px;
-    color: black;
 }
 
 .lang_list li a:hover {
     text-decoration: none;
-    color:black;
 }


### PR DESCRIPTION
Links are already not underlined on the tool's interface; overriding the default color to be black, like the rest of the text, leads them to lose any visual cues that they are active elements of the page.

Removing the color and underline hints from links makes the page harder to use, and indeed is recommended against in most accessibility and usability guidelines.